### PR TITLE
Update upstream to jdk19u

### DIFF
--- a/.github/workflows/refresh-jdk.yml
+++ b/.github/workflows/refresh-jdk.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 8 * * *'
   workflow_dispatch:
 env:
-  UPSTREAM_REMOTE: https://github.com/openjdk/jdk19.git
+  UPSTREAM_REMOTE: https://github.com/openjdk/jdk19u.git
   LOCAL_BRANCH: develop
 jobs:
     refresh-jdk:


### PR DESCRIPTION
The upstream is changed to jdk19u.  This is a noop change since we already import the latest code from 19u, just in case I would like to have a correct link.