### PR TITLE
8301397: [11u, 17u] Bump jtreg to fix issue with build JDK 11.0.18

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -26,7 +26,7 @@
 # Versions and download locations for dependencies used by GitHub Actions (GHA)
 
 GTEST_VERSION=1.8.1
-JTREG_VERSION=6.1+2
+JTREG_VERSION=6.1+3
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
 LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk18/43f95e8614114aeaa8e8a5fcf20a682d/36/GPL/openjdk-18_linux-x64_bin.tar.gz


### PR DESCRIPTION
This is the fix for the broken workflow. The version of jtreg is updated.
The patch is ported from the [17u](https://github.com/openjdk/jdk17u-dev/commit/0e98d6a81a395741f992df97d98b4e07679951ea)